### PR TITLE
Initial license metrics monitoring and test cases

### DIFF
--- a/configs/grafana/dashboards/default.yml
+++ b/configs/grafana/dashboards/default.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+- name: 'defaults'
+  orgId: 1
+  folder: ''
+  type: file
+  disableDeletion: false
+  editable: true
+  options:
+    path: /etc/grafana/provisioning/dashboards

--- a/configs/grafana/dashboards/licensing.json
+++ b/configs/grafana/dashboards/licensing.json
@@ -1,0 +1,344 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "5.0.0-beta5"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": "5.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "5.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "singlestat",
+      "name": "Singlestat",
+      "version": "5.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "Prometheus",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 6,
+        "x": 0,
+        "y": 7
+      },
+      "hideTimeOverride": false,
+      "id": 1,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "__name__",
+      "targets": [
+        {
+          "expr": "qix_active_documents",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "timeFrom": null,
+      "title": "Active documents",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "Prometheus",
+      "format": "none",
+      "gauge": {
+        "maxValue": 10000,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 6,
+        "x": 0,
+        "y": 7
+      },
+      "hideTimeOverride": false,
+      "id": 2,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "__name__",
+      "targets": [
+        {
+          "expr": "license_time_total",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "timeFrom": null,
+      "title": "License time in total",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "Prometheus",
+      "format": "none",
+      "gauge": {
+        "maxValue": 10000,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 6,
+        "x": 0,
+        "y": 7
+      },
+      "hideTimeOverride": false,
+      "id": 6,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "__name__",
+      "targets": [
+        {
+          "expr": "license_time_consumption",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "timeFrom": null,
+      "title": "License time consumed in total",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Qlik Core Licensing Monitoring",
+  "uid": "Q_YQu56kz",
+  "version": 2
+}

--- a/configs/grafana/dashboards/licensing.json
+++ b/configs/grafana/dashboards/licensing.json
@@ -116,7 +116,7 @@
       "tableColumn": "__name__",
       "targets": [
         {
-          "expr": "qix_active_documents",
+          "expr": "qix_active_sessions",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -124,7 +124,7 @@
       ],
       "thresholds": "",
       "timeFrom": null,
-      "title": "Active documents",
+      "title": "Active sessions in total",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -294,7 +294,7 @@
       "valueMaps": [
         {
           "op": "=",
-          "text": "N/A",
+          "text": "0",
           "value": "null"
         }
       ],

--- a/configs/grafana/datasources/prometheus.yml
+++ b/configs/grafana/datasources/prometheus.yml
@@ -1,0 +1,15 @@
+apiVersion: 1
+
+deleteDatasources:
+  - name: Prometheus
+    orgId: 1
+
+datasources:
+- name: Prometheus
+  type: prometheus
+  access: proxy
+  orgId: 1
+  url: http://prometheus:9090
+  isDefault: true
+  version: 1
+  editable: true

--- a/configs/prometheus/config.yml
+++ b/configs/prometheus/config.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 1s
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+  - job_name: 'qix-engine'
+    static_configs:
+      - targets: ['qix-engine:9090']
+  - job_name: 'licenses'
+    static_configs:
+      - targets: ['licenses:9200']

--- a/docker-compose.engine-and-license-service.yml
+++ b/docker-compose.engine-and-license-service.yml
@@ -4,8 +4,6 @@ services:
 
   qix-engine:
     image: qlikcore/engine:12.171.0
-    deploy:
-      replicas: 2
     command: -S AcceptEULA=${ACCEPT_EULA} -S LicenseServiceUrl=http://licenses:9200 -S DisableStartupLicenseCheck=1 -S TrafficLogVerbosity=5 -S SystemLogVerbosity=5
     ports:
       - 19076:9076

--- a/docker-compose.metrics.yml
+++ b/docker-compose.metrics.yml
@@ -1,0 +1,18 @@
+version: "3.0"
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.1.0
+    command: '--config.file=/etc/prometheus/config.yml'
+    volumes:
+      - ./configs/prometheus/config.yml:/etc/prometheus/config.yml
+  grafana:
+    image: grafana/grafana:5.0.4
+    ports:
+      - "3000:3000"
+    environment:
+      GF_AUTH_ANONYMOUS_ENABLED: 'true'
+      GF_AUTH_ANONYMOUS_ORG_ROLE: 'Admin'
+    volumes:
+      - ./configs/grafana/datasources:/etc/grafana/provisioning/datasources
+      - ./configs/grafana/dashboards:/etc/grafana/provisioning/dashboards

--- a/test/utils_test.go
+++ b/test/utils_test.go
@@ -22,12 +22,12 @@ func getTestHost() string {
 var (
 	ctx     = context.Background()
 	headers = make(http.Header, 1)
-	Host    = getTestHost()
+	host    = getTestHost()
 )
 
 func ConnectToEngineAndReturnOnConnectedEventMessage(ctx context.Context, sessionID int, headers http.Header) (string, error) {
 	headers.Set("X-Qlik-Session", fmt.Sprintf("%d", sessionID))
-	global, err := enigma.Dialer{}.Dial(ctx, fmt.Sprintf("ws://%s:19076/app/engineData/", Host), headers)
+	global, err := enigma.Dialer{}.Dial(ctx, fmt.Sprintf("ws://%s:19076/app/engineData/", host), headers)
 
 	if err != nil {
 		fmt.Println(err.Error())

--- a/test/utils_test.go
+++ b/test/utils_test.go
@@ -22,12 +22,12 @@ func getTestHost() string {
 var (
 	ctx     = context.Background()
 	headers = make(http.Header, 1)
-	host    = getTestHost()
+	Host    = getTestHost()
 )
 
 func ConnectToEngineAndReturnOnConnectedEventMessage(ctx context.Context, sessionID int, headers http.Header) (string, error) {
 	headers.Set("X-Qlik-Session", fmt.Sprintf("%d", sessionID))
-	global, err := enigma.Dialer{}.Dial(ctx, fmt.Sprintf("ws://%s:19076/app/engineData/", host), headers)
+	global, err := enigma.Dialer{}.Dial(ctx, fmt.Sprintf("ws://%s:19076/app/engineData/", Host), headers)
 
 	if err != nil {
 		fmt.Println(err.Error())

--- a/test/with_license_test.go
+++ b/test/with_license_test.go
@@ -1,17 +1,93 @@
 package test
 
 import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
+type MetricsItem []struct {
+	Name   string `json:"name"`
+	Metric Metric `json:"metric"`
+}
+
+type Metric []struct {
+	Gauge Gauge `json:"gauge"`
+}
+
+type Gauge struct {
+	Value int `json:"value"`
+}
+
+var (
+	client = &http.Client{}
+)
+
+func getNumberActiveQixSessions() int {
+	req, _ := http.NewRequest("GET", fmt.Sprintf("http://%s:9090/metrics", Host), nil)
+	req.Header.Add("Accept", "application/json")
+	resp, _ := client.Do(req)
+	body, _ := ioutil.ReadAll(resp.Body)
+
+	var metrics MetricsItem
+	json.Unmarshal(body, &metrics)
+
+	var activeSessions int
+	for _, metric := range metrics {
+		if metric.Name == "qix_active_sessions" {
+			activeSessions = metric.Metric[0].Gauge.Value
+		}
+	}
+	return activeSessions
+}
+
+func getLicensesMetrics() string {
+	req, _ := http.NewRequest("GET", fmt.Sprintf("http://%s:9200/metrics", Host), nil)
+	resp, _ := client.Do(req)
+	body, _ := ioutil.ReadAll(resp.Body)
+	return string(body)
+}
+
+func getLicenseTimeConsumed() int {
+	licensesMetrics := getLicensesMetrics()
+	re := regexp.MustCompile(`\nlicense_time_consumption{.*}\s(\d+)\n`)
+	matched := re.FindStringSubmatch(licensesMetrics)
+	timeConsumed, _ := strconv.Atoi(matched[1])
+	return timeConsumed
+}
+
+func getLicenseTimeTotal() int {
+	licensesMetrics := getLicensesMetrics()
+	re := regexp.MustCompile(`\nlicense_time_total{.*}\s(\d+)\n`)
+	matched := re.FindStringSubmatch(licensesMetrics)
+	totalTime, _ := strconv.Atoi(matched[1])
+	return totalTime
+}
+
 func TestThatMoreThanFiveSessionsWorkWithALicense(t *testing.T) {
 
-	for i := 0; i < 10; i++ {
+	var nbrIterations = 10
+	var costPerSession = 6
+	var totalTimeLicense = 1000
+
+	for i := 0; i < nbrIterations; i++ {
 		message, err := ConnectToEngineAndReturnOnConnectedEventMessage(ctx, i, headers)
 		assert.Equal(t, "SESSION_CREATED", message)
 		assert.Nil(t, err, "Connecting to engine should not give an error")
 	}
 
+	// Verify that the number of active sessions in Qlik Analytics Engine metrics matches number of sessions opened in test case
+	assert.Equal(t, nbrIterations, getNumberActiveQixSessions())
+
+	// Verify that the license time consumed reported on Licenses metrics matches the expected time consumed
+	assert.Equal(t, nbrIterations*costPerSession, getLicenseTimeConsumed())
+
+	// Verify total license time reported in Licenses metrics is the expected value
+	assert.Equal(t, totalTimeLicense, getLicenseTimeTotal())
 }

--- a/test/with_license_test.go
+++ b/test/with_license_test.go
@@ -30,7 +30,7 @@ var (
 )
 
 func getNumberActiveQixSessions() int {
-	req, _ := http.NewRequest("GET", fmt.Sprintf("http://%s:9090/metrics", Host), nil)
+	req, _ := http.NewRequest("GET", fmt.Sprintf("http://%s:9090/metrics", host), nil)
 	req.Header.Add("Accept", "application/json")
 	resp, _ := client.Do(req)
 	body, _ := ioutil.ReadAll(resp.Body)
@@ -48,7 +48,7 @@ func getNumberActiveQixSessions() int {
 }
 
 func getLicensesMetrics() string {
-	req, _ := http.NewRequest("GET", fmt.Sprintf("http://%s:9200/metrics", Host), nil)
+	req, _ := http.NewRequest("GET", fmt.Sprintf("http://%s:9200/metrics", host), nil)
 	resp, _ := client.Do(req)
 	body, _ := ioutil.ReadAll(resp.Body)
 	return string(body)

--- a/test/with_license_test.go
+++ b/test/with_license_test.go
@@ -54,16 +54,14 @@ func getLicensesMetrics() string {
 	return string(body)
 }
 
-func getLicenseTimeConsumed() int {
-	licensesMetrics := getLicensesMetrics()
+func getLicenseTimeConsumed(licensesMetrics string) int {
 	re := regexp.MustCompile(`\nlicense_time_consumption{.*}\s(\d+)\n`)
 	matched := re.FindStringSubmatch(licensesMetrics)
 	timeConsumed, _ := strconv.Atoi(matched[1])
 	return timeConsumed
 }
 
-func getLicenseTimeTotal() int {
-	licensesMetrics := getLicensesMetrics()
+func getLicenseTimeTotal(licensesMetrics string) int {
 	re := regexp.MustCompile(`\nlicense_time_total{.*}\s(\d+)\n`)
 	matched := re.FindStringSubmatch(licensesMetrics)
 	totalTime, _ := strconv.Atoi(matched[1])
@@ -73,8 +71,8 @@ func getLicenseTimeTotal() int {
 func TestThatMoreThanFiveSessionsWorkWithALicense(t *testing.T) {
 
 	var nbrIterations = 10
-	var costPerSession = 6
-	var totalTimeLicense = 1000
+	var costPerSession = 6      // Each session cost x nbr of analyzer minutes
+	var totalTimeLicense = 1000 // Total number of analyzer minutes specified in license
 
 	for i := 0; i < nbrIterations; i++ {
 		message, err := ConnectToEngineAndReturnOnConnectedEventMessage(ctx, i, headers)
@@ -86,8 +84,9 @@ func TestThatMoreThanFiveSessionsWorkWithALicense(t *testing.T) {
 	assert.Equal(t, nbrIterations, getNumberActiveQixSessions())
 
 	// Verify that the license time consumed reported on Licenses metrics matches the expected time consumed
-	assert.Equal(t, nbrIterations*costPerSession, getLicenseTimeConsumed())
+	licensesMetrics := getLicensesMetrics()
+	assert.Equal(t, nbrIterations*costPerSession, getLicenseTimeConsumed(licensesMetrics))
 
 	// Verify total license time reported in Licenses metrics is the expected value
-	assert.Equal(t, totalTimeLicense, getLicenseTimeTotal())
+	assert.Equal(t, totalTimeLicense, getLicenseTimeTotal(licensesMetrics))
 }


### PR DESCRIPTION
This PR adds an additonal docker-compose file that can be started together with the qix-engine and licenses service:
`ACCEPT_EULA=yes docker-compose -f docker-compose.engine-and-license-service.yml -f docker-compose.metrics.yml up -d`

In Grafana there will be a dashboard with three default Gauges for monitoring QIX Engine and Licenses metrics. 

Also added verification steps in existing license test case for verifying the metrics.
