### PR TITLE
Adding some sleep to make the tests less shaky

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,8 @@ jobs:
             TEST_CONTAINER=$(docker run -e TEST_HOST=$TEST_HOST -d golang:1.9-alpine tail -f /dev/null)
             # Copy code into container
             docker cp /go/src/github.com/qlik-oss/core-using-licenses/ $TEST_CONTAINER:/go/src/license_test/
+            # Sleep for 10s to make sure the license service has contacted the backend.
+            sleep 10s
             # Execute tests
             docker exec $TEST_CONTAINER sh -c 'go test -timeout 30s /go/src/license_test/test/no_license_test.go /go/src/license_test/test/utils_test.go -count=1'
             # Bring down the docker-compose and test container
@@ -54,6 +56,8 @@ jobs:
             TEST_CONTAINER=$(docker run -e TEST_HOST=$TEST_HOST -d golang:1.9-alpine tail -f /dev/null)
             # Copy code into container
             docker cp /go/src/github.com/qlik-oss/core-using-licenses/ $TEST_CONTAINER:/go/src/license_test/
+            # Sleep for 10s to make sure the license service has contacted the backend.
+            sleep 10s
             # Execute tests
             docker exec $TEST_CONTAINER sh -c 'go test -timeout 30s /go/src/license_test/test/with_license_test.go /go/src/license_test/test/utils_test.go -count=1'
             # Bring down the docker-compose


### PR DESCRIPTION
In the future, the license service might add a /ready endpoint we could check against before starting our test.

But for now, I've added some sleep to make it more stable.